### PR TITLE
Update InstancePing.proto

### DIFF
--- a/register/InstancePing.proto
+++ b/register/InstancePing.proto
@@ -31,6 +31,6 @@ service ServiceInstancePing {
 
 message ServiceInstancePingPkg {
     int32 serviceInstanceId = 1;
-    string serviceInstanceCode = 1;
     int64 time = 2;
+    string serviceInstanceCode = 3;
 }

--- a/register/InstancePing.proto
+++ b/register/InstancePing.proto
@@ -32,5 +32,5 @@ service ServiceInstancePing {
 message ServiceInstancePingPkg {
     int32 serviceInstanceId = 1;
     int64 time = 2;
-    string serviceInstanceCode = 3;
+    string serviceInstanceUUID = 3;
 }

--- a/register/InstancePing.proto
+++ b/register/InstancePing.proto
@@ -31,5 +31,6 @@ service ServiceInstancePing {
 
 message ServiceInstancePingPkg {
     int32 serviceInstanceId = 1;
+    string serviceInstanceCode = 1;
     int64 time = 2;
 }


### PR DESCRIPTION
Add the instance_code parameter to the heartbeat protocol for #1585, so that the backend server can identify the instance of lost metadata.