### PR TITLE
Fix proto gen conflict

### DIFF
--- a/common/CLR.proto
+++ b/common/CLR.proto
@@ -19,8 +19,8 @@
 syntax = "proto3";
 
 option java_multiple_files = true;
-option java_package = "org.apache.skywalking.apm.network.language.agent";
-option csharp_namespace = "SkyWalking.NetworkProtocol";
+option java_package = "org.apache.skywalking.apm.network.language.agent.clr";
+option csharp_namespace = "SkyWalking.NetworkProtocol.Clr";
 
 message CLRMetric {
     int64 time = 1;
@@ -43,6 +43,6 @@ message GC {
 message Thread {
     int32 AvailableCompletionPortThreads = 1;
     int32 AvailableWorkerThreads = 2;
-    int32 MaxCompletionPortThreads = 1;
-    int32 MaxWorkerThreads = 2;
+    int32 MaxCompletionPortThreads = 3;
+    int32 MaxWorkerThreads = 4;
 }

--- a/common/CLR.proto
+++ b/common/CLR.proto
@@ -19,28 +19,26 @@
 syntax = "proto3";
 
 option java_multiple_files = true;
-option java_package = "org.apache.skywalking.apm.network.language.agent.clr";
-option csharp_namespace = "SkyWalking.NetworkProtocol.Clr";
+option java_package = "org.apache.skywalking.apm.network.language.agent";
+option csharp_namespace = "SkyWalking.NetworkProtocol";
+
+import "common/common.proto";
 
 message CLRMetric {
     int64 time = 1;
     CPU cpu = 2;
-    GC gc = 3;
-    Thread thread = 4;
+    ClrGC gc = 3;
+    ClrThread thread = 4;
 }
 
-message CPU {
-    double usagePercent = 1;
-}
-
-message GC {
+message ClrGC {
     int64 Gen0CollectCount = 1;
     int64 Gen1CollectCount = 2;
     int64 Gen2CollectCount = 3;
     int64 HeapMemory = 4;
 }
 
-message Thread {
+message ClrThread {
     int32 AvailableCompletionPortThreads = 1;
     int32 AvailableWorkerThreads = 2;
     int32 MaxCompletionPortThreads = 3;

--- a/common/JVM.proto
+++ b/common/JVM.proto
@@ -22,16 +22,14 @@ option java_multiple_files = true;
 option java_package = "org.apache.skywalking.apm.network.language.agent";
 option csharp_namespace = "SkyWalking.NetworkProtocol";
 
+import "common/common.proto";
+
 message JVMMetric {
     int64 time = 1;
     CPU cpu = 2;
     repeated Memory memory = 3;
     repeated MemoryPool memoryPool = 4;
     repeated GC gc = 5;
-}
-
-message CPU {
-    double usagePercent = 2;
 }
 
 message Memory {

--- a/common/common.proto
+++ b/common/common.proto
@@ -32,6 +32,10 @@ message KeyIntValuePair {
     int32 value = 2;
 }
 
+message CPU {
+    double usagePercent = 2;
+}
+
 // In most cases, detect point should be `server` or `client`.
 // Even in service mesh, this means `server`/`client` side sidecar
 // `proxy` is reserved only.

--- a/language-agent-v2/CLRMetric.proto
+++ b/language-agent-v2/CLRMetric.proto
@@ -19,8 +19,8 @@
 syntax = "proto3";
 
 option java_multiple_files = true;
-option java_package = "org.apache.skywalking.apm.network.language.agent.v2";
-option csharp_namespace = "SkyWalking.NetworkProtocol";
+option java_package = "org.apache.skywalking.apm.network.language.agent.v2.clr";
+option csharp_namespace = "SkyWalking.NetworkProtocol.Clr";
 
 import "common/common.proto";
 import "common/CLR.proto";

--- a/language-agent-v2/CLRMetric.proto
+++ b/language-agent-v2/CLRMetric.proto
@@ -19,8 +19,8 @@
 syntax = "proto3";
 
 option java_multiple_files = true;
-option java_package = "org.apache.skywalking.apm.network.language.agent.v2.clr";
-option csharp_namespace = "SkyWalking.NetworkProtocol.Clr";
+option java_package = "org.apache.skywalking.apm.network.language.agent.v2";
+option csharp_namespace = "SkyWalking.NetworkProtocol";
 
 import "common/common.proto";
 import "common/CLR.proto";


### PR DESCRIPTION
When I generate java code from proto. The following error was thrown
```
[ERROR] PROTOC FAILED: common/CLR.proto:33:12: "CPU.usagePercent" is already defined in file "common/JVM.proto".
common/CLR.proto:32:9: "CPU" is already defined in file "common/JVM.proto".
common/CLR.proto:36:9: "GC" is already defined in file "common/JVM.proto".
common/CLR.proto:27:5: "CPU" seems to be defined in "common/JVM.proto", which is not imported by "common/CLR.proto".  To use it here, please add the necessary import.
common/CLR.proto:28:5: "GC" seems to be defined in "common/JVM.proto", which is not imported by "common/CLR.proto".  To use it here, please add the necessary import.
common/CLR.proto:46:38: Field number 1 has already been used in "Thread" by field "AvailableCompletionPortThreads".
common/CLR.proto:47:30: Field number 2 has already been used in "Thread" by field "AvailableWorkerThreads".
language-agent-v2/CLRMetric.proto: Import "common/CLR.proto" was not found or had errors.
language-agent-v2/CLRMetric.proto:34:14: "CLRMetric" is not defined.

```